### PR TITLE
run load handlers on next frame

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,4 +1,5 @@
 // adapted from https://github.com/timwis/choo-leaflet-demo/blob/master/src/index.js
+var microbounce = require('microbounce')
 var html = require('choo/html')
 var css = require('sheetify')
 var log = require('choo-log')
@@ -16,6 +17,7 @@ app.use(store)
 app.route('/', mainView)
 app.mount('body')
 
+var debounce = microbounce(128)
 function mainView (state, emit) {
   return html`
     <body>
@@ -34,7 +36,10 @@ function mainView (state, emit) {
   `
 
   function updateTitle (evt) {
-    emit('update-title', evt.target.value)
+    var value = evt.target.value
+    debounce(function () {
+      emit('update-title', value)
+    })
   }
 
   function toPhiladelphia () {

--- a/example/leaflet.js
+++ b/example/leaflet.js
@@ -25,7 +25,7 @@ Leaflet.prototype._render = function (coords) {
 
   if (!this._map) {
     this._element = html`<div style="height: 500px"></div>`
-    this._createMap()
+    if (this._hasWindow) this._createMap()
   } else {
     onIdle(function () {
       self._updateMap()

--- a/index.js
+++ b/index.js
@@ -26,12 +26,20 @@ Nanocomponent.prototype.render = function () {
     this._element = this._render.apply(this, args)
     this._onload(this._element, function () {
       self._loaded = true
-      if (self._load) self._load()
+      if (self._load) {
+        window.requestAnimationFrame(function () {
+          self._load()
+        })
+      }
     }, function () {
       self._placeholder = null
       self._element = null
       self._loaded = false
-      if (self._unload) self._unload()
+      if (self._unload) {
+        window.requestAnimationFrame(function () {
+          self._unload()
+        })
+      }
     })
     return this._element
   } else {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "inherits": "^2.0.3",
     "istanbul": "^0.4.5",
     "leaflet": "^1.0.3",
+    "microbounce": "^1.0.0",
     "nanologger": "^1.0.2",
     "on-idle": "^1.0.0",
     "standard": "^8.6.0",


### PR DESCRIPTION
Noticed that triggering UI changes from `_onload` triggered all sorts of deopts. Although people should probably be aware, making sure it doesn't deopt will make it so people don't accidentally forget. Great when integrating with third party libraries where you're not necessarily sure what's happening under the hood.

Also snuck in a quick check into the example so it can be run without any issues in Node. Yayay.