### PR TITLE
remove default ._update

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ renders. The Node that's initially returned is saved as `this._element`.
 
 ### `Nanocomponent.prototype._update([arguments])`
 Return a boolean to determine if `prototype._render()` should be called.
-Evaluates to `true` if not implemented. Not called on the first render.
+Not called on the first render.
 
 ### `Nanocomponent.prototype._load()`
 Called when the component is mounted on the DOM.

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function Nanocomponent (val) {
 
 Nanocomponent.prototype.render = function () {
   assert.equal(typeof this._render, 'function', 'nanocomponent: this._render should be implemented')
+  assert.equal(typeof this._update, 'function', 'nanocomponent: this._update should be implemented')
 
   var self = this
   var len = arguments.length
@@ -48,11 +49,6 @@ Nanocomponent.prototype.render = function () {
     if (!this._placeholder) this._placeholder = this._createPlaceholder()
     return this._placeholder
   }
-}
-
-// default ._update method - should be replaced with custom logic
-Nanocomponent.prototype._update = function () {
-  return true
 }
 
 Nanocomponent.prototype._createPlaceholder = function () {


### PR DESCRIPTION
Every component should expose a `._update()` method, and it's easy to miss if you say implement `.update()` by mistake.