### PR TITLE
set default id

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 var onload = require('on-load')
 var assert = require('assert')
 
+var KEY = 'ncid-' + (new Date() % 9e6).toString(36)
+var INDEX = 0
+
 module.exports = Nanocomponent
 
 function Nanocomponent (val) {
   this._hasWindow = typeof window !== 'undefined'
+  this._ID = KEY + '-' + INDEX++
   this._placeholder = null
   this._onload = onload
   this._element = null
@@ -25,6 +29,12 @@ Nanocomponent.prototype.render = function () {
     return this._element
   } else if (!this._element) {
     this._element = this._render.apply(this, args)
+
+    // Get ID - needed for nanomorph child element reordering
+    var id = this._element.getAttribute('id')
+    if (!id) this._element.setAttribute('id', this._ID)
+    else this._ID = id
+
     this._onload(this._element, function () {
       self._loaded = true
       if (self._load) {
@@ -54,6 +64,7 @@ Nanocomponent.prototype.render = function () {
 Nanocomponent.prototype._createPlaceholder = function () {
   var el = document.createElement('div')
   el.setAttribute('data-nanocomponent', '')
+  el.setAttribute('id', this._ID)
   var self = this
   el.isSameNode = function (el) {
     return el === self._element


### PR DESCRIPTION
Nanomorph (will very soon) check for IDs in element lists. To prevent the placeholder element from accidentally being rendered, nanocomponent elements should always have an ID present.

if `._element` has an id on it already, we don't modify it and will set it to our placeholder elements going forward.

---
- related to https://github.com/yoshuawuyts/nanomorph/issues/8
- cc/ @juliangruber 