### PR TITLE
remove placeholder concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ Object.create(Nanocomponent.prototype)`.
 
 Internal properties are:
 
-- `this._placeholder`: placeholder element that's returned on subsequent
-  `render()` calls that don't pass the `._update()` check.
 - `this._element`: rendered element that should be returned from the first
   `._render()` call. Used to apply `._load()` and `._unload()` listeners on.
 - `this._hasWindow`: boolean if `window` exists. Can be used to create
@@ -96,12 +94,11 @@ Internal properties are:
 - `this._loaded`: boolean if the element is currently loaded on the DOM.
 - `this._onload`: reference to the [on-load][on-load] library.
 
-### `DOMNode|placeholder = Nanocomponent.prototype.render()`
+### `DOMNode = Nanocomponent.prototype.render()`
 Create an instance of the component. Calls `prototype._render()` if
 `prototype._update()` returns `true`. As long as the element is mounted on the
-DOM, subsequent calls to `.render()` will return a placeholder element with a
-`.isSameNode()` method that compares arguments with the previously rendered
-node. This is useful for diffing algorithms like
+DOM, subsequent calls to `.render()` will return exactly the cachde element.
+This is useful for diffing algorithms like
 [nanomorph](https://github.com/yoshuawuyts/nanomorph) which use this method to
 determine if a portion of the tree should be walked.
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ module.exports = Nanocomponent
 function Nanocomponent (val) {
   this._hasWindow = typeof window !== 'undefined'
   this._ID = KEY + '-' + INDEX++
-  this._placeholder = null
   this._onload = onload
   this._element = null
   this._loaded = false
@@ -46,7 +45,6 @@ Nanocomponent.prototype.render = function () {
         })
       }
     }, function () {
-      self._placeholder = null
       self._element = null
       self._loaded = false
       if (self._unload) {
@@ -62,18 +60,7 @@ Nanocomponent.prototype.render = function () {
       this._render.apply(this, args)
       this._ensureID()
     }
-    if (!this._placeholder) this._placeholder = this._createPlaceholder()
-    return this._placeholder
+    return this._element
   }
 }
 
-Nanocomponent.prototype._createPlaceholder = function () {
-  var el = document.createElement('div')
-  el.setAttribute('data-nanocomponent', '')
-  el.setAttribute('id', this._ID)
-  var self = this
-  el.isSameNode = function (el) {
-    return el === self._element
-  }
-  return el
-}


### PR DESCRIPTION
https://github.com/moroshko/shallow-equal/pull/2#issuecomment-298434028 raised a concern that I didn't have an answer for, why do we even use `.isSameNode()` when we can just check for strict equality `===`.

Nanomorph will stop looking into a node's children when `a.isSameNode(b)` which is true when `a === b` by default. So no need to even return the placeholder. As a bonus, we won't see the placeholder in the dom any more for cases where say people render and reorder lists without implementing the `ID` convention.