### PR TITLE
fix render after update

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ Nanocomponent.prototype.render = function () {
   } else {
     var shouldUpdate = this._update.apply(this, args)
     if (shouldUpdate) {
-      this._render.apply(this, args)
+      this._element = this._render.apply(this, args)
       this._ensureID()
     }
     if (!this._placeholder) this._placeholder = this._createPlaceholder()


### PR DESCRIPTION
before, when using this through microcomponent, this._render() would
be microcomponent's fn which would internally call to nanomorph.
we needed to change microcomponent's architecture however, to override
this.render() instead of this._render(). thus, setting this._element
after this._render() is required because otherwise this._element isn't
updated