### PR TITLE
remove clearing of ._{element,placeholder} on unload

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,8 +54,6 @@ Nanocomponent.prototype.render = function (props) {
         })
       }
     }, function () {
-      self._placeholder = null
-      self._element = null
       self._loaded = false
       if (self._unload) {
         window.requestAnimationFrame(function () {


### PR DESCRIPTION
this was causing issues as eg when nodes are reordered, unload will fire and then onload. then, this._element would be null but it's actually there, in the DOM.